### PR TITLE
Fixes JSON double-parsing errors

### DIFF
--- a/web-app/network/network.js
+++ b/web-app/network/network.js
@@ -118,7 +118,7 @@ module.exports = {
       console.log('\nGet member state ');
       const memberResponse = await contract.evaluateTransaction('GetState', accountNumber);
       console.log('memberResponse.parse_response: ')
-      console.log(JSON.parse(JSON.parse(memberResponse.toString())));
+      console.log(JSON.parse(memberResponse.toString()));
 
       // Disconnect from the gateway.
       await gateway2.disconnect();
@@ -224,7 +224,7 @@ module.exports = {
       console.log('\nGet partner state ');
       const partnerResponse = await contract.evaluateTransaction('GetState', partnerId);
       console.log('partnerResponse.parse_response: ')
-      console.log(JSON.parse(JSON.parse(partnerResponse.toString())));
+      console.log(JSON.parse(partnerResponse.toString()));
 
       // Disconnect from the gateway.
       await gateway2.disconnect();
@@ -368,7 +368,7 @@ module.exports = {
 
       console.log('\nGet member state ');
       let member = await contract.submitTransaction('GetState', accountNumber);
-      member = JSON.parse(JSON.parse(member.toString()));
+      member = JSON.parse(member.toString());
       console.log(member);
 
       // Disconnect from the gateway.
@@ -409,9 +409,8 @@ module.exports = {
       // Get the contract from the network.
       const contract = network.getContract('customerloyalty');
 
-      console.log('\nGet partner state ');
       let partner = await contract.submitTransaction('GetState', partnerId);
-      partner = JSON.parse(JSON.parse(partner.toString()));
+      partner = JSON.parse(partner.toString());
       console.log(partner);
 
       // Disconnect from the gateway.
@@ -453,7 +452,7 @@ module.exports = {
 
       console.log('\nGet all partners state ');
       let allPartners = await contract.evaluateTransaction('GetState', 'all-partners');
-      allPartners = JSON.parse(JSON.parse(allPartners.toString()));
+      allPartners = JSON.parse(allPartners.toString());
       console.log(allPartners);
 
       // Disconnect from the gateway.
@@ -494,7 +493,7 @@ module.exports = {
 
       console.log(`\nGet earn points transactions state for ${userType} ${userId}`);
       let earnPointsTransactions = await contract.evaluateTransaction('EarnPointsTransactionsInfo', userType, userId);
-      earnPointsTransactions = JSON.parse(JSON.parse(earnPointsTransactions.toString()));
+      earnPointsTransactions = JSON.parse(earnPointsTransactions.toString());
       console.log(earnPointsTransactions);
 
       // Disconnect from the gateway.
@@ -536,7 +535,7 @@ module.exports = {
 
       console.log(`\nGet use points transactions state for ${userType} ${userId}`);
       let usePointsTransactions = await contract.evaluateTransaction('UsePointsTransactionsInfo', userType, userId);
-      usePointsTransactions = JSON.parse(JSON.parse(usePointsTransactions.toString()));
+      usePointsTransactions = JSON.parse(usePointsTransactions.toString());
       console.log(usePointsTransactions);
 
       // Disconnect from the gateway.


### PR DESCRIPTION
This addresses #7 

At several locations in network.js of the web app `JSON.parse` was being double-applied to JSON strings, resulting in `Unexpected token o in JSON at position 1` error in the browser during registration, sign-in, etc.